### PR TITLE
Add the introductory blog post for Awesome RSI

### DIFF
--- a/site/src/components/BlogTab.jsx
+++ b/site/src/components/BlogTab.jsx
@@ -58,6 +58,9 @@ function ArticleBlock({ block }) {
       </List>
     );
   }
+  if (block.type === "footnote") {
+    return <p className="blog-footnote">{renderInline(block.text)}</p>;
+  }
   return <p>{renderInline(block.text)}</p>;
 }
 

--- a/site/src/components/BlogTab.jsx
+++ b/site/src/components/BlogTab.jsx
@@ -15,6 +15,52 @@ function postIdFromHash() {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
+// Minimal inline markup so post text stays plain-string and easy to hand-edit:
+// [label](url) becomes a link, **text** becomes bold. Everything else is literal.
+function renderInline(text) {
+  const nodes = [];
+  const pattern = /\[([^\]]+)\]\(([^)]+)\)|\*\*([^*]+)\*\*/g;
+  let lastIndex = 0;
+  let match;
+  let key = 0;
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+    if (match[1] !== undefined) {
+      const external = /^https?:\/\//.test(match[2]);
+      nodes.push(
+        <a
+          key={key++}
+          href={match[2]}
+          {...(external ? { target: "_blank", rel: "noreferrer" } : {})}
+        >
+          {match[1]}
+        </a>,
+      );
+    } else {
+      nodes.push(<strong key={key++}>{match[3]}</strong>);
+    }
+    lastIndex = pattern.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+  return nodes;
+}
+
+function ArticleBlock({ block }) {
+  if (block.type === "list") {
+    const List = block.ordered ? "ol" : "ul";
+    return (
+      <List>
+        {block.items.map((item, index) => <li key={index}>{renderInline(item)}</li>)}
+      </List>
+    );
+  }
+  return <p>{renderInline(block.text)}</p>;
+}
+
 function BlogIndex({ onOpenPost }) {
   return (
     <section className="blog-index" aria-label="Blog posts">
@@ -56,12 +102,23 @@ function BlogArticle({ post, onBack }) {
       <h2 id="blog-article-title">{post.title}</h2>
       <p className="blog-article-lead">{post.summary}</p>
 
-      <section className="blog-article-body" aria-labelledby="release-highlights-title">
-        <h3 id="release-highlights-title">What’s included</h3>
-        <ul>
-          {post.highlights.map((highlight) => <li key={highlight}>{highlight}</li>)}
-        </ul>
-      </section>
+      {post.sections
+        ? post.sections.map((section, index) => (
+            <section className="blog-article-body" key={section.heading ?? index}>
+              {section.heading ? <h3>{section.heading}</h3> : null}
+              {section.blocks.map((block, blockIndex) => (
+                <ArticleBlock block={block} key={blockIndex} />
+              ))}
+            </section>
+          ))
+        : (
+          <section className="blog-article-body" aria-labelledby="release-highlights-title">
+            <h3 id="release-highlights-title">What’s included</h3>
+            <ul>
+              {post.highlights.map((highlight) => <li key={highlight}>{highlight}</li>)}
+            </ul>
+          </section>
+        )}
     </article>
   );
 }

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -12,43 +12,48 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "The idea is old. In 1965 I.J. Good described an **intelligence explosion**: since designing machines is itself an intellectual task, a capable enough machine could design a better one, which designs a better one still — **\"the first ultraintelligent machine is the last invention that man need ever make.\"** Yudkowsky's self-rewriting \"seed AI\" and Bostrom's *Superintelligence* (2014) carried the theme forward, but for decades it stayed a thought experiment about a hypothetical future.",
+            text: "The idea is old. In 1965 I.J. Good described an **intelligence explosion**: since designing machines is itself an intellectual task, a capable enough machine could design a better one, which designs a better one still — **\"the first ultraintelligent machine is the last invention that man need ever make.\"** Yudkowsky's self-rewriting \"seed AI\" and Bostrom's **Superintelligence** (2014) carried the theme forward, but for decades it stayed a thought experiment about a hypothetical future.",
           },
           {
             type: "p",
-            text: "It is no longer hypothetical. The capabilities of large language model agents have made recursive self-improvement (RSI) appear reachable, and the literature is expanding accordingly. Three difficulties follow. **First**, the term is unstable: much as with \"world model,\" it is applied loosely, so that editing a prompt and retraining model weights are both called RSI and few authors mean quite the same thing. **Second**, the field is growing faster than it is being organized — a July 2026 survey ([arXiv:2607.07663](https://arxiv.org/abs/2607.07663)) catalogues **1,250** arXiv papers from 2024–2026 — yet little of this work has been synthesized into a comparable whole. **Third**, the pace has outrun its pedagogy: there is no settled course or textbook, and newcomers lack an obvious entry point.",
+            text: "However, it is no longer hypothetical now. The capabilities of large language models have made recursive self-improvement (RSI) appear reachable, and the literature is expanding accordingly. Three difficulties follow. First, the term is unstable: much as with \"world model,\" it is applied loosely and few authors mean quite the same thing. Second, the field is growing faster than it is being organized — a July 2026 survey ([arXiv:2607.07663](https://arxiv.org/abs/2607.07663)) catalogues **1,250** arXiv papers from 2024–2026 — yet little of it has been brought together so the papers can be compared. Third, the pace has outrun its pedagogy: there is no settled course or textbook, and newcomers lack an obvious entry point.",
           },
           {
             type: "p",
-            text: "Awesome RSI addresses each in turn. **First**, rather than adjudicate what qualifies as \"real\" RSI, we define the notion along a set of orthogonal dimensions and locate each system by its position on them. **Second**, we present the same corpus through complementary views — a filterable, sortable benchmark list and a verified citation graph — so that benchmarks and methods may be compared as a timeline, a leaderboard, or a map. **Third**, we assemble the books and courses worth reading into a single curated shelf. The remainder of this post treats each in order.",
+            text: "Awesome RSI addresses each in turn. First, rather than adjudicate what qualifies as \"real\" RSI, we define the notion along a set of orthogonal dimensions and locate each system by its position on them. Second, we present the same corpus through complementary views — a filterable, sortable benchmark list and a verified citation graph — so that benchmarks and methods may be compared as a timeline, a leaderboard, or a map. Third, we assemble the books and courses worth reading into a single curated shelf. The remainder of this post treats each in order.",
           },
         ],
       },
       {
-        heading: "The definition, and how we slice it",
+        heading: "The definition and its dimensions",
         blocks: [
           {
             type: "p",
-            text: "Large language model agents turned it into an engineering question. Today RSI usually means something concrete and measurable: an agent that improves its **own** future performance by editing one of its **own** building blocks — parametric ones such as model parameters, or non-parametric ones such as **context**, **memory**, **skills**, and **harness/scaffold code** — using feedback drawn from its own work. The question is no longer *when the singularity arrives*, but which block changes, what signal drives the change, and whether anything measurably improved.",
+            text: "We define RSI as a process where an agent improves its **own** future performance by editing one of its **own** building blocks — parametric ones such as model parameters, or non-parametric ones such as **context**, **memory**, **skills**, and **harness/scaffold code** — using feedback drawn from its own work.",
           },
           {
             type: "p",
-            text: "Those questions are, in effect, a set of dimensions. Rather than adjudicate membership, we characterize each system along a few axes:",
-          },
-          {
-            type: "list",
-            ordered: false,
-            items: [
-              "**What evolves.** Which building block changes — non-parametric context, memory, skills, or harness code, as against genuinely parametric recursion in which one model generation trains the next.",
-              "**How it evolves.** Whether experience arrives online as a stream or curriculum, through a fixed offline train/test split, or a hybrid that seeds a skill library offline and continues to adapt in use.",
-              "**Where the signal originates.** What supervises the improvement — a rule-based check, an external verifier, an LLM judge, or a self-generated reward.",
-              "**How far the loop closes.** The degree of remaining human involvement, from human-in-the-loop to a fully closed loop.",
-              "**What is measured.** Final accuracy, the *gain* over a non-evolving baseline, cost, or latency — of which gain, rather than final accuracy, is often the more informative.",
-            ],
+            text: "This definition is broad. To make it precise — and to compare different kinds of RSI — we sharpen it along the three dimensions that are most often misread; further dimensions are documented on the site.",
           },
           {
             type: "p",
-            text: "These are the axes the benchmark list is tagged with, so the corpus can be filtered by the definition itself.",
+            text: "**1. Which building block is edited.** The edited block may be *parametric* (the model's own weights) or *non-parametric* (anything outside the weights: context, memory, skills, or harness code). The distinction is smaller than it looks. An agent's output is drawn from P(y | θ, C), where y is the output, θ the model parameters, and C the context given to the model. Parametric edits change θ; every non-parametric edit ultimately changes C, or what enters it. Both act on the same distribution.",
+          },
+          {
+            type: "p",
+            text: "This dimension is easy to misattribute. In PostTrainBench ([arXiv:2603.08640](https://arxiv.org/abs/2603.08640)) a teacher agent trains a student model and raises its accuracy over successive rounds. It is tempting to call the student the self-improving system, but the system performing RSI is the teacher agent: when a round underperforms — say, the loss is high — the teacher adjusts the learning rate, the training-data distribution, or the model architecture, and the resulting experience accumulates in its context and, as the run lengthens, is written out to memory or skills. The setup is essentially meta-learning — the teacher learns how to make the student learn — so training the student is merely the task on which the teacher improves.",
+          },
+          {
+            type: "p",
+            text: "**2. How the improvement is structured.** Three arrangements recur. *Offline RSI* resembles supervised learning: the agent attempts labeled training tasks, receives a supervision signal, consolidates the experience into skills or memory (or trains it back into the base model), and is then evaluated on a held-out test set — for example, GDPevo ([arXiv:2608.03764](https://arxiv.org/abs/2608.03764)). *Online RSI* resembles reinforcement learning, with training and test on the same task: the agent works a single task continuously, accumulating knowledge in its environment to maximize expected reward over a long horizon, balancing exploration and exploitation — for example, EdgeBench ([arXiv:2607.05155](https://arxiv.org/abs/2607.05155)) and the PostTrainBench setup above. *Mixed RSI* combines the two, continuing to consolidate new experience during the test phase of an otherwise offline protocol.",
+          },
+          {
+            type: "p",
+            text: "**3. The remaining axes.** Others distinguish systems further. The evaluation *metric* need not be accuracy alone; cost and time matter too, since useful self-improvement should be faster and cheaper as well as more accurate. The *source of the supervision signal* is a separate axis — a score or a reference answer, drawn from the environment or from a labeled training set. And for benchmarks specifically, two more: whether the benchmark is built from scratch or assembled from existing ones, and whether it is authored by hand or generated automatically by an agent.",
+          },
+          {
+            type: "p",
+            text: "These are among the axes the benchmark list is tagged with, so the corpus can be filtered by the definition itself.",
           },
         ],
       },

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -2,10 +2,10 @@ export const blogPosts = [
   {
     id: "introducing-awesome-rsi",
     kind: "Introduction",
-    title: "Awesome RSI: A Comprehensive Collection with Clear Definitions and Comparison Dimensions",
+    title: "Awesome RSI: A Comprehensive Collection with Dimensioned Definitions",
     published: "2026-08-21",
     summary:
-      "Recursive self-improvement is moving faster than its own vocabulary. This post introduces our own precise, dimensioned definition; comparison views over the papers; and a curated shelf of books and courses.",
+      "Recursive self-improvement is moving faster than its own vocabulary. This post introduces our own dimensioned definition; comparison views over the papers; and a curated shelf of books and courses.",
     tags: ["intro", "RSI", "definition", "benchmarks"],
     sections: [
       {
@@ -14,10 +14,6 @@ export const blogPosts = [
           {
             type: "p",
             text: "The idea is old. In 1965 I.J. Good described an *intelligence explosion*: since designing machines is itself an intellectual task, a capable enough machine could design a better one, which designs a better one still — **\"the first ultraintelligent machine is the last invention that man need ever make.\"** Yudkowsky's self-rewriting \"seed AI\" and Bostrom's *Superintelligence* (2014) carried the theme forward, but for decades it stayed a thought experiment about a hypothetical future.",
-          },
-          {
-            type: "p",
-            text: "Large language model agents turned it into an engineering question. Today RSI usually means something concrete and measurable: an agent that improves its **own** future performance by editing one of its **own** building blocks — parametric ones such as model parameters, or non-parametric ones such as **context**, **memory**, **skills**, and **harness/scaffold code** — using feedback drawn from its own work. The question is no longer *when the singularity arrives*, but which block changes, what signal drives the change, and whether anything measurably improved.",
           },
         ],
       },
@@ -44,14 +40,14 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "Awesome RSI answers each of those problems directly:",
+            text: "Awesome RSI answers each of those three problems in turn:",
           },
           {
             type: "list",
             ordered: true,
             items: [
-              "**A precise, dimensioned definition.** We give a concrete definition and break it into orthogonal dimensions, so systems are described by *where they sit* on each axis rather than by whether they earn the label.",
-              "**Comparison views over the corpus.** The same collection is offered as a filterable benchmark list, sortable by date or citations, plus a verified citation graph — a timeline, a leaderboard, and a map at once.",
+              "**Dimensions instead of one label.** We define RSI along a set of orthogonal dimensions, so systems are described by *where they sit* on each axis rather than by whether they earn the label.",
+              "**Comparison views over the corpus.** The same collection is offered as a filterable benchmark list, sortable by date or citations, plus a citation graph — a timeline, a leaderboard, and a map that let benchmarks and methods be compared horizontally and vertically.",
               "**A curated learning shelf.** We surveyed the books, courses, and materials on RSI and collected the worthwhile ones in one place, so there is finally a single on-ramp.",
             ],
           },
@@ -62,15 +58,11 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "Here is our current working definition — a draft, meant to be argued with and refined:",
+            text: "Large language model agents turned it into an engineering question. Today RSI usually means something concrete and measurable: an agent that improves its **own** future performance by editing one of its **own** building blocks — parametric ones such as model parameters, or non-parametric ones such as **context**, **memory**, **skills**, and **harness/scaffold code** — using feedback drawn from its own work. The question is no longer *when the singularity arrives*, but which block changes, what signal drives the change, and whether anything measurably improved.",
           },
           {
             type: "p",
-            text: "*A recursive self-improvement system improves its own future performance by modifying one of its own building blocks — context, memory, skills, harness/scaffold code, or model parameters — using a feedback signal derived from its own activity, with the improvement carried forward to later tasks.*",
-          },
-          {
-            type: "p",
-            text: "A single label can't capture that, so we describe each system along a few dimensions:",
+            text: "Those questions are really a set of dimensions. Rather than police who counts as \"real\" RSI, we describe each system along a few axes:",
           },
           {
             type: "list",

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -49,11 +49,11 @@ export const blogPosts = [
           },
           {
             type: "p",
-            text: "**2. How the improvement is structured.** Three arrangements recur. *Offline RSI* resembles supervised learning: the agent attempts labeled training tasks, receives a supervision signal, consolidates the experience into skills or memory (or trains it back into the base model), and is then evaluated on a held-out test set — for example, GDPevo ([arXiv:2608.03764](https://arxiv.org/abs/2608.03764)). *Online RSI* resembles reinforcement learning, with training and test on the same task: the agent works a single task continuously, accumulating knowledge in its environment to maximize expected reward over a long horizon, balancing exploration and exploitation — for example, EdgeBench ([arXiv:2607.05155](https://arxiv.org/abs/2607.05155)) and the PostTrainBench setup above. *Mixed RSI* combines the two, continuing to consolidate new experience during the test phase of an otherwise offline protocol.",
+            text: "**2. How the improvement is structured.** First, offline RSI resembles supervised learning: the agent attempts labeled training tasks, receives a supervision signal, consolidates the experience into skills or memory (or trains it back into the base model), and is then evaluated on a held-out test set — for example, GDPevo ([arXiv:2608.03764](https://arxiv.org/abs/2608.03764)). Second, online RSI resembles reinforcement learning, with training and test on the same task: the agent works a single task continuously, accumulating knowledge in its environment to maximize expected reward over a long horizon, balancing exploration and exploitation — for example, EdgeBench ([arXiv:2607.05155](https://arxiv.org/abs/2607.05155)) and the PostTrainBench setup above. Third, mixed RSI combines the two, continuing to consolidate new experience during the test phase of an otherwise offline setting.",
           },
           {
             type: "p",
-            text: "**3. The remaining axes.** Others distinguish systems further. The evaluation *metric* need not be accuracy alone; cost and time matter too, since useful self-improvement should be faster and cheaper as well as more accurate. The *source of the supervision signal* is a separate axis — a score or a reference answer, drawn from the environment or from a labeled training set. And for benchmarks specifically, two more: whether the benchmark is built from scratch or assembled from existing ones, and whether it is authored by hand or generated automatically by an agent.",
+            text: "**3. The remaining axes.** Others distinguish systems further. The evaluation metric need not be accuracy alone; cost and time matter too, since useful self-improvement should be faster and cheaper as well as more accurate. The source of the supervision signal is a separate axis — a score or a reference answer, drawn from the environment or from a labeled training set. And for benchmarks specifically, two more: whether the benchmark is built from scratch or assembled from existing ones, and whether it is authored by hand or generated automatically by an agent.",
           },
           {
             type: "p",
@@ -66,7 +66,7 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "This is more than a paper list; the same corpus can be examined from several angles. First, the list can be sorted by year or by citation count. Second, it can be filtered by the dimensions of the previous section: selecting values across dimensions returns only the papers that satisfy all of them, and noting which combinations return few or no papers can point to an underexplored direction worth pursuing. Third, a citation graph shows how the papers reference one another, annotated with year and citation count. Fourth, we separate benchmark work from method work, so the two can be consulted independently.",
+            text: "Awesome RSI is more than a paper list; the same corpus can be examined from several angles. First, the list can be sorted by year or by citation count. Second, it can be filtered by the dimensions of the previous section: selecting values across dimensions returns only the papers that satisfy all of them, and noting which combinations return few or no papers can point to an underexplored direction worth pursuing. Third, a citation graph shows how the papers reference one another, annotated with year and citation count. Fourth, we separate benchmark work from method work, so the two can be consulted independently.",
           },
         ],
       },
@@ -75,7 +75,7 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "As no textbook yet exists, we have gathered the material worth reading into a single shelf: technical books on agent memory and self-evolution, university courses such as Stanford's CS329A and Harvard's CS2881R, and surveys and harness write-ups that survey the field. It is collected under the **Books & Courses** tab and is updated as strong material appears.",
+            text: "We gathered the material worth reading into a single shelf: technical books on agent memory and self-evolution, university courses such as Stanford's CS329A and Harvard's CS2881R, and surveys and harness write-ups that review the field. It is collected under the **Books & Courses** tab and is updated as strong material appears.",
           },
         ],
       },

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -9,47 +9,18 @@ export const blogPosts = [
     tags: ["intro", "RSI", "definition", "benchmarks"],
     sections: [
       {
-        heading: "What is recursive self-improvement?",
         blocks: [
           {
             type: "p",
-            text: "The idea is old. In 1965 I.J. Good described an *intelligence explosion*: since designing machines is itself an intellectual task, a capable enough machine could design a better one, which designs a better one still — **\"the first ultraintelligent machine is the last invention that man need ever make.\"** Yudkowsky's self-rewriting \"seed AI\" and Bostrom's *Superintelligence* (2014) carried the theme forward, but for decades it stayed a thought experiment about a hypothetical future.",
+            text: "The idea is old. In 1965 I.J. Good described an **intelligence explosion**: since designing machines is itself an intellectual task, a capable enough machine could design a better one, which designs a better one still — **\"the first ultraintelligent machine is the last invention that man need ever make.\"** Yudkowsky's self-rewriting \"seed AI\" and Bostrom's *Superintelligence* (2014) carried the theme forward, but for decades it stayed a thought experiment about a hypothetical future.",
           },
-        ],
-      },
-      {
-        heading: "Three things that make RSI hard to follow",
-        blocks: [
           {
             type: "p",
-            text: "The field is exciting precisely because it is unsettled — which also makes it hard to navigate. Three problems stand out:",
+            text: "It is no longer hypothetical. The capabilities of large language model agents have made recursive self-improvement (RSI) appear reachable, and the literature is expanding accordingly. Three difficulties follow. **First**, the term is unstable: much as with \"world model,\" it is applied loosely, so that editing a prompt and retraining model weights are both called RSI and few authors mean quite the same thing. **Second**, the field is growing faster than it is being organized — a July 2026 survey ([arXiv:2607.07663](https://arxiv.org/abs/2607.07663)) catalogues **1,250** arXiv papers from 2024–2026 — yet little of this work has been synthesized into a comparable whole. **Third**, the pace has outrun its pedagogy: there is no settled course or textbook, and newcomers lack an obvious entry point.",
           },
-          {
-            type: "list",
-            ordered: true,
-            items: [
-              "**The definition won't sit still.** Like \"world model,\" the term is used loosely — editing a prompt and retraining weights both get called \"RSI\" — so everyone means something slightly different.",
-              "**It grows faster than anyone can summarize.** A July 2026 survey ([arXiv:2607.07663](https://arxiv.org/abs/2607.07663)) scanned **1,250** arXiv papers on recursive self-improvement from 2024–2026, yet there is little synthesis of how they relate or compare.",
-              "**The learning materials can't keep up.** The field moves too fast for a settled course or textbook, so a newcomer has no obvious on-ramp.",
-            ],
-          },
-        ],
-      },
-      {
-        heading: "What this project does about it",
-        blocks: [
           {
             type: "p",
-            text: "Awesome RSI answers each of those three problems in turn:",
-          },
-          {
-            type: "list",
-            ordered: true,
-            items: [
-              "**Dimensions instead of one label.** We define RSI along a set of orthogonal dimensions, so systems are described by *where they sit* on each axis rather than by whether they earn the label.",
-              "**Comparison views over the corpus.** The same collection is offered as a filterable benchmark list, sortable by date or citations, plus a citation graph — a timeline, a leaderboard, and a map that let benchmarks and methods be compared horizontally and vertically.",
-              "**A curated learning shelf.** We surveyed the books, courses, and materials on RSI and collected the worthwhile ones in one place, so there is finally a single on-ramp.",
-            ],
+            text: "Awesome RSI addresses each in turn. **First**, rather than adjudicate what qualifies as \"real\" RSI, we define the notion along a set of orthogonal dimensions and locate each system by its position on them. **Second**, we present the same corpus through complementary views — a filterable, sortable benchmark list and a verified citation graph — so that benchmarks and methods may be compared as a timeline, a leaderboard, or a map. **Third**, we assemble the books and courses worth reading into a single curated shelf. The remainder of this post treats each in order.",
           },
         ],
       },
@@ -62,22 +33,22 @@ export const blogPosts = [
           },
           {
             type: "p",
-            text: "Those questions are really a set of dimensions. Rather than police who counts as \"real\" RSI, we describe each system along a few axes:",
+            text: "Those questions are, in effect, a set of dimensions. Rather than adjudicate membership, we characterize each system along a few axes:",
           },
           {
             type: "list",
             ordered: false,
             items: [
-              "**What evolves.** Which building block actually changes — non-parametric context, memory, skills, or harness code, versus genuinely parametric recursion where one model generation trains the next.",
-              "**How it evolves.** Whether experience arrives online as a stream or curriculum, through a clean offline train/test split, or a hybrid that seeds a skill library offline and keeps evolving in use.",
-              "**Where the signal comes from.** What supervises the improvement — a rule-based check, an external verifier, an LLM judge, or a self-generated reward.",
-              "**How far the loop closes.** How much human involvement remains, from human-in-the-loop to a fully closed loop.",
-              "**What we measure.** Final accuracy, the *gain* over a non-evolving baseline, cost, or latency — gain, not accuracy, is often the honest metric.",
+              "**What evolves.** Which building block changes — non-parametric context, memory, skills, or harness code, as against genuinely parametric recursion in which one model generation trains the next.",
+              "**How it evolves.** Whether experience arrives online as a stream or curriculum, through a fixed offline train/test split, or a hybrid that seeds a skill library offline and continues to adapt in use.",
+              "**Where the signal originates.** What supervises the improvement — a rule-based check, an external verifier, an LLM judge, or a self-generated reward.",
+              "**How far the loop closes.** The degree of remaining human involvement, from human-in-the-loop to a fully closed loop.",
+              "**What is measured.** Final accuracy, the *gain* over a non-evolving baseline, cost, or latency — of which gain, rather than final accuracy, is often the more informative.",
             ],
           },
           {
             type: "p",
-            text: "These are the same axes the benchmark list is tagged with, so you can filter the corpus by the definition itself.",
+            text: "These are the axes the benchmark list is tagged with, so the corpus can be filtered by the definition itself.",
           },
         ],
       },
@@ -92,11 +63,19 @@ export const blogPosts = [
             type: "list",
             ordered: false,
             items: [
-              "**Benchmark Paper List** — the benchmark corpus with a seven-dimension filter board (origin, RSI mode, artifact, construction, metric, creation, evaluation), plus full-text search and sorting by date or citations.",
-              "**Citation graph** — a verified graph of how the papers cite one another, with pan-and-zoom, to read the corpus as a map rather than a list.",
-              "**Methods & Systems** — the methods side of the field: how self-improvement is actually done, kept alongside the benchmarks that measure it.",
-              "**Books & Courses** — the curated learning shelf of technical books, university courses, and other materials.",
+              "**Benchmark Paper List** — the benchmark corpus with a seven-dimension filter board (origin, RSI mode, artifact, construction, metric, creation, evaluation), full-text search, and sorting by date or citations.",
+              "**Citation graph** — a verified graph of how the papers cite one another, with pan-and-zoom, presenting the corpus as a map rather than a list.",
+              "**Methods & Systems** — the methods side of the field: how self-improvement is carried out, kept alongside the benchmarks that measure it.",
             ],
+          },
+        ],
+      },
+      {
+        heading: "Books & courses",
+        blocks: [
+          {
+            type: "p",
+            text: "As no textbook yet exists, we have gathered the material worth reading into a single shelf: technical books on agent memory and self-evolution, university courses such as Stanford's CS329A and Harvard's CS2881R, and surveys and harness write-ups that survey the field. It is collected under the **Books & Courses** tab and is updated as strong material appears.",
           },
         ],
       },
@@ -105,15 +84,7 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "This is a living map, and it improves with more eyes on it. If a benchmark, method, or resource is missing — or a taxonomy label looks wrong — open a pull request or an issue; new entries carry the taxonomy metadata so they drop straight into the filter views.",
-          },
-          {
-            type: "list",
-            ordered: false,
-            items: [
-              "Repository and contribution guide: [github.com/Prism-Shadow/awesome-rsi](https://github.com/Prism-Shadow/awesome-rsi)",
-              "Background reading — the survey behind the 1,250-paper figure: [Recursive Self-Improvement in AI (arXiv:2607.07663)](https://arxiv.org/abs/2607.07663)",
-            ],
+            text: "Awesome RSI is intended as a living map, and it improves with additional review. If a paper, method, or resource is missing — or a taxonomy label appears incorrect — please open a pull request or an issue at [github.com/Prism-Shadow/awesome-rsi](https://github.com/Prism-Shadow/awesome-rsi). New entries carry the taxonomy metadata and integrate directly into the filter views.",
           },
         ],
       },

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -29,11 +29,15 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "We define RSI as a process where an agent improves its **own** future performance by editing one of its **own** building blocks — parametric ones such as model parameters, or non-parametric ones such as **context**, **memory**, **skills**, and **harness/scaffold code** — using feedback drawn from its own work.",
+            text: "We define RSI as a process where an agent improves its **own** future performance by editing one of its **own** building blocks — parametric ones such as model parameters, or non-parametric ones such as **context**, **memory**, **skills**, and **harness code** — using feedback drawn from its own work or from the outside world.¹",
+          },
+          {
+            type: "footnote",
+            text: "¹ The external source matters: it has been argued that with no signal from outside at all, self-improvement is impossible in principle — an information-theoretic limit on how much a system can bootstrap from itself alone.",
           },
           {
             type: "p",
-            text: "This definition is broad. To make it precise — and to compare different kinds of RSI — we sharpen it along the three dimensions that are most often misread; further dimensions are documented on the site.",
+            text: "This definition is broad. To make it precise — and to compare different kinds of RSI — we sharpen it along the two dimensions that are most often misread; further dimensions are documented on the site.",
           },
           {
             type: "p",
@@ -62,16 +66,7 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "The same papers can be read in more than one way:",
-          },
-          {
-            type: "list",
-            ordered: false,
-            items: [
-              "**Benchmark Paper List** — the benchmark corpus with a seven-dimension filter board (origin, RSI mode, artifact, construction, metric, creation, evaluation), full-text search, and sorting by date or citations.",
-              "**Citation graph** — a verified graph of how the papers cite one another, with pan-and-zoom, presenting the corpus as a map rather than a list.",
-              "**Methods & Systems** — the methods side of the field: how self-improvement is carried out, kept alongside the benchmarks that measure it.",
-            ],
+            text: "This is more than a paper list; the same corpus can be examined from several angles. First, the list can be sorted by year or by citation count. Second, it can be filtered by the dimensions of the previous section: selecting values across dimensions returns only the papers that satisfy all of them, and noting which combinations return few or no papers can point to an underexplored direction worth pursuing. Third, a citation graph shows how the papers reference one another, annotated with year and citation count. Fourth, we separate benchmark work from method work, so the two can be consulted independently.",
           },
         ],
       },

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -2,10 +2,10 @@ export const blogPosts = [
   {
     id: "introducing-awesome-rsi",
     kind: "Introduction",
-    title: "Awesome RSI: A Map for a Field That Won't Hold Still",
+    title: "Awesome RSI: A Comprehensive Collection with Clear Definitions and Comparison Dimensions",
     published: "2026-08-21",
     summary:
-      "Recursive self-improvement is moving faster than its own vocabulary. This post introduces the field, names the three things that make it hard to follow, and explains how this project responds — a precise, dimensioned definition; comparison views over the corpus; and a curated shelf of books and courses.",
+      "Recursive self-improvement is moving faster than its own vocabulary. This post introduces our own precise, dimensioned definition; comparison views over the papers; and a curated shelf of books and courses.",
     tags: ["intro", "RSI", "definition", "benchmarks"],
     sections: [
       {
@@ -13,11 +13,11 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "The idea is old. In 1965 I.J. Good, who had worked alongside Turing at Bletchley Park, described an *intelligence explosion*: since designing machines is itself an intellectual task, a sufficiently capable machine could design an even better machine, which could design a better one still. In his words, **\"the first ultraintelligent machine is the last invention that man need ever make.\"** The theme was carried forward by Yudkowsky's notion of a self-rewriting \"seed AI\" and by Bostrom's *Superintelligence* (2014) — but for decades it stayed a thought experiment about a hypothetical future.",
+            text: "The idea is old. In 1965 I.J. Good described an *intelligence explosion*: since designing machines is itself an intellectual task, a capable enough machine could design a better one, which designs a better one still — **\"the first ultraintelligent machine is the last invention that man need ever make.\"** Yudkowsky's self-rewriting \"seed AI\" and Bostrom's *Superintelligence* (2014) carried the theme forward, but for decades it stayed a thought experiment about a hypothetical future.",
           },
           {
             type: "p",
-            text: "Large language model agents have turned it into an engineering question. Today, recursive self-improvement (RSI) most often means something concrete and measurable: an agent that improves its own future performance by editing one of its own building blocks — its **context**, **memory**, **skills**, **harness/scaffold code**, or **model parameters** — using feedback drawn from its own work. The singularity framing has given way to a practical one: which building block changes, what signal drives the change, and can we actually measure that anything got better.",
+            text: "Large language model agents turned it into an engineering question. Today RSI usually means something concrete and measurable: an agent that improves its **own** future performance by editing one of its **own** building blocks — parametric ones such as model parameters, or non-parametric ones such as **context**, **memory**, **skills**, and **harness/scaffold code** — using feedback drawn from its own work. The question is no longer *when the singularity arrives*, but which block changes, what signal drives the change, and whether anything measurably improved.",
           },
         ],
       },
@@ -26,15 +26,15 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "The field is exciting precisely because it is unsettled. But that also makes it hard to navigate. Three problems stand out:",
+            text: "The field is exciting precisely because it is unsettled — which also makes it hard to navigate. Three problems stand out:",
           },
           {
             type: "list",
             ordered: true,
             items: [
-              "**The definition won't sit still.** Much like \"world model,\" the term is used loosely and inconsistently. \"RSI,\" \"self-evolving,\" \"self-improving,\" and \"lifelong\" get applied to systems that differ on almost every axis — editing a prompt versus retraining weights, a single self-refinement pass versus genuine multi-generation recursion, a human in the loop versus a fully closed one. You say one thing, I say another, and the same word covers all of it.",
-              "**It's growing faster than anyone can summarize.** A July 2026 survey ([arXiv:2607.07663](https://arxiv.org/abs/2607.07663)) scanned **1,250** arXiv papers on recursive self-improvement from 2024–2026. New benchmarks and methods appear month over month, but there is little synthesis of how they relate, where they overlap, and how they should be compared side by side.",
-              "**The learning materials can't keep up.** Because the field moves so quickly, there is no settled course or textbook to follow. A newcomer who wants to get oriented has no obvious on-ramp, and good material is scattered across preprints, lecture playlists, and blog posts.",
+              "**The definition won't sit still.** Like \"world model,\" the term is used loosely — editing a prompt and retraining weights both get called \"RSI\" — so everyone means something slightly different.",
+              "**It grows faster than anyone can summarize.** A July 2026 survey ([arXiv:2607.07663](https://arxiv.org/abs/2607.07663)) scanned **1,250** arXiv papers on recursive self-improvement from 2024–2026, yet there is little synthesis of how they relate or compare.",
+              "**The learning materials can't keep up.** The field moves too fast for a settled course or textbook, so a newcomer has no obvious on-ramp.",
             ],
           },
         ],
@@ -44,15 +44,15 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "Awesome RSI responds to each of those three problems directly:",
+            text: "Awesome RSI answers each of those problems directly:",
           },
           {
             type: "list",
             ordered: true,
             items: [
-              "**A precise, dimensioned definition.** We give a concrete working definition and — more usefully — break it into orthogonal dimensions, so \"RSI\" stops being one word doing too much work. Two systems can then be described by *where they sit* on each dimension rather than by whether they earn the label.",
-              "**Comparison views over the corpus.** We host the same collection as several views — a benchmark paper list backed by a multi-dimensional filter board, sortable by date or by citations, plus a verified citation graph — so the corpus can be read as a timeline, a leaderboard, or a map, and papers can be compared across dimensions horizontally and vertically.",
-              "**A curated learning shelf.** We surveyed the books, courses, and learning materials on RSI from across the web and collected the worthwhile ones in one place, so there is finally a single on-ramp to point newcomers to.",
+              "**A precise, dimensioned definition.** We give a concrete definition and break it into orthogonal dimensions, so systems are described by *where they sit* on each axis rather than by whether they earn the label.",
+              "**Comparison views over the corpus.** The same collection is offered as a filterable benchmark list, sortable by date or citations, plus a verified citation graph — a timeline, a leaderboard, and a map at once.",
+              "**A curated learning shelf.** We surveyed the books, courses, and materials on RSI and collected the worthwhile ones in one place, so there is finally a single on-ramp.",
             ],
           },
         ],
@@ -70,22 +70,22 @@ export const blogPosts = [
           },
           {
             type: "p",
-            text: "A single label can't capture that. So rather than police who counts as \"real\" RSI, we describe each system along a set of dimensions:",
+            text: "A single label can't capture that, so we describe each system along a few dimensions:",
           },
           {
             type: "list",
             ordered: false,
             items: [
-              "**What evolves (the artifact).** Which building block actually changes? This ranges from non-parametric artifacts — context, memory, skills, harness code — to genuinely parametric recursion where one model generation trains the next. \"Improving the context\" and \"retraining the weights\" are both self-improvement, but they are not the same thing.",
-              "**How it evolves (the mode).** Does experience arrive online as a stream or curriculum, is there a clean offline train/test split, or is it a hybrid that seeds a skill library offline and keeps evolving in use?",
-              "**Where the signal comes from.** What supervises the improvement — a rule-based check or execution result, an external verifier, an LLM acting as judge, or a self-generated reward? Every improvement loop is an implicit claim that some signal can stand in for human judgment.",
-              "**How far the loop closes.** How much human involvement remains, from human-in-the-loop at one end to a fully closed loop at the other.",
-              "**What we measure.** Final accuracy, the *gain* over a matched non-evolving baseline, the cost (tokens, compute, money), or the latency. A system can post high final accuracy with almost no RSI gain if it simply started strong — which is why gain, not accuracy, is often the honest metric.",
+              "**What evolves.** Which building block actually changes — non-parametric context, memory, skills, or harness code, versus genuinely parametric recursion where one model generation trains the next.",
+              "**How it evolves.** Whether experience arrives online as a stream or curriculum, through a clean offline train/test split, or a hybrid that seeds a skill library offline and keeps evolving in use.",
+              "**Where the signal comes from.** What supervises the improvement — a rule-based check, an external verifier, an LLM judge, or a self-generated reward.",
+              "**How far the loop closes.** How much human involvement remains, from human-in-the-loop to a fully closed loop.",
+              "**What we measure.** Final accuracy, the *gain* over a non-evolving baseline, cost, or latency — gain, not accuracy, is often the honest metric.",
             ],
           },
           {
             type: "p",
-            text: "These are the same axes the benchmark list is tagged with, so the definition isn't just prose — you can filter the corpus by it.",
+            text: "These are the same axes the benchmark list is tagged with, so you can filter the corpus by the definition itself.",
           },
         ],
       },
@@ -94,16 +94,16 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "The site is built so the same papers can be examined in more than one way:",
+            text: "The same papers can be read in more than one way:",
           },
           {
             type: "list",
             ordered: false,
             items: [
-              "**Benchmark Paper List** — the curated benchmark corpus, with a filter board spanning seven dimensions (benchmark origin, RSI mode, RSI artifact, construction criteria, metric, benchmark creation, and evaluation). Values within a dimension combine with OR and dimensions combine with AND, so you can isolate, say, streaming online benchmarks that report gain and are scored by rule-based checks. Search across titles and abstracts, and sort by recency or by citation count.",
-              "**Citation graph** — a verified graph of how these papers cite one another, with pan-and-zoom on desktop and mobile, to read the corpus as a map rather than a list.",
+              "**Benchmark Paper List** — the benchmark corpus with a seven-dimension filter board (origin, RSI mode, artifact, construction, metric, creation, evaluation), plus full-text search and sorting by date or citations.",
+              "**Citation graph** — a verified graph of how the papers cite one another, with pan-and-zoom, to read the corpus as a map rather than a list.",
               "**Methods & Systems** — the methods side of the field: how self-improvement is actually done, kept alongside the benchmarks that measure it.",
-              "**Books & Courses** — the curated learning shelf: technical books, university courses, and other learning materials for getting oriented.",
+              "**Books & Courses** — the curated learning shelf of technical books, university courses, and other materials.",
             ],
           },
         ],
@@ -113,7 +113,7 @@ export const blogPosts = [
         blocks: [
           {
             type: "p",
-            text: "This is meant to be a living map, and it gets better with more eyes on it. If a benchmark, method, or learning resource is missing — or a taxonomy label looks wrong — please open a pull request or an issue on the repository. New entries come with the taxonomy metadata described above so they slot straight into the filter views.",
+            text: "This is a living map, and it improves with more eyes on it. If a benchmark, method, or resource is missing — or a taxonomy label looks wrong — open a pull request or an issue; new entries carry the taxonomy metadata so they drop straight into the filter views.",
           },
           {
             type: "list",

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -127,18 +127,4 @@ export const blogPosts = [
       },
     ],
   },
-  {
-    id: "release-notes-2026-08",
-    kind: "Release notes",
-    title: "Awesome RSI — The First Release",
-    published: "2026-08-19",
-    summary: "A benchmark-focused research map for tracking how agents improve through memory, skills, feedback, and long-horizon interaction.",
-    tags: ["release", "benchmark", "citation graph"],
-    highlights: [
-      "Expanded the collection to 24 RSI benchmark papers with reviewed taxonomy metadata.",
-      "Added multi-dimensional filtering across benchmark origin, RSI mode, evolving artifacts, construction criteria, metrics, creation, and evaluation.",
-      "Introduced a verified citation graph with desktop and mobile pan-and-zoom interactions.",
-      "Improved responsive navigation, dark mode, paper search, sorting, and citation inspection.",
-    ],
-  },
 ];

--- a/site/src/data/blogPosts.js
+++ b/site/src/data/blogPosts.js
@@ -1,5 +1,133 @@
 export const blogPosts = [
   {
+    id: "introducing-awesome-rsi",
+    kind: "Introduction",
+    title: "Awesome RSI: A Map for a Field That Won't Hold Still",
+    published: "2026-08-21",
+    summary:
+      "Recursive self-improvement is moving faster than its own vocabulary. This post introduces the field, names the three things that make it hard to follow, and explains how this project responds — a precise, dimensioned definition; comparison views over the corpus; and a curated shelf of books and courses.",
+    tags: ["intro", "RSI", "definition", "benchmarks"],
+    sections: [
+      {
+        heading: "What is recursive self-improvement?",
+        blocks: [
+          {
+            type: "p",
+            text: "The idea is old. In 1965 I.J. Good, who had worked alongside Turing at Bletchley Park, described an *intelligence explosion*: since designing machines is itself an intellectual task, a sufficiently capable machine could design an even better machine, which could design a better one still. In his words, **\"the first ultraintelligent machine is the last invention that man need ever make.\"** The theme was carried forward by Yudkowsky's notion of a self-rewriting \"seed AI\" and by Bostrom's *Superintelligence* (2014) — but for decades it stayed a thought experiment about a hypothetical future.",
+          },
+          {
+            type: "p",
+            text: "Large language model agents have turned it into an engineering question. Today, recursive self-improvement (RSI) most often means something concrete and measurable: an agent that improves its own future performance by editing one of its own building blocks — its **context**, **memory**, **skills**, **harness/scaffold code**, or **model parameters** — using feedback drawn from its own work. The singularity framing has given way to a practical one: which building block changes, what signal drives the change, and can we actually measure that anything got better.",
+          },
+        ],
+      },
+      {
+        heading: "Three things that make RSI hard to follow",
+        blocks: [
+          {
+            type: "p",
+            text: "The field is exciting precisely because it is unsettled. But that also makes it hard to navigate. Three problems stand out:",
+          },
+          {
+            type: "list",
+            ordered: true,
+            items: [
+              "**The definition won't sit still.** Much like \"world model,\" the term is used loosely and inconsistently. \"RSI,\" \"self-evolving,\" \"self-improving,\" and \"lifelong\" get applied to systems that differ on almost every axis — editing a prompt versus retraining weights, a single self-refinement pass versus genuine multi-generation recursion, a human in the loop versus a fully closed one. You say one thing, I say another, and the same word covers all of it.",
+              "**It's growing faster than anyone can summarize.** A July 2026 survey ([arXiv:2607.07663](https://arxiv.org/abs/2607.07663)) scanned **1,250** arXiv papers on recursive self-improvement from 2024–2026. New benchmarks and methods appear month over month, but there is little synthesis of how they relate, where they overlap, and how they should be compared side by side.",
+              "**The learning materials can't keep up.** Because the field moves so quickly, there is no settled course or textbook to follow. A newcomer who wants to get oriented has no obvious on-ramp, and good material is scattered across preprints, lecture playlists, and blog posts.",
+            ],
+          },
+        ],
+      },
+      {
+        heading: "What this project does about it",
+        blocks: [
+          {
+            type: "p",
+            text: "Awesome RSI responds to each of those three problems directly:",
+          },
+          {
+            type: "list",
+            ordered: true,
+            items: [
+              "**A precise, dimensioned definition.** We give a concrete working definition and — more usefully — break it into orthogonal dimensions, so \"RSI\" stops being one word doing too much work. Two systems can then be described by *where they sit* on each dimension rather than by whether they earn the label.",
+              "**Comparison views over the corpus.** We host the same collection as several views — a benchmark paper list backed by a multi-dimensional filter board, sortable by date or by citations, plus a verified citation graph — so the corpus can be read as a timeline, a leaderboard, or a map, and papers can be compared across dimensions horizontally and vertically.",
+              "**A curated learning shelf.** We surveyed the books, courses, and learning materials on RSI from across the web and collected the worthwhile ones in one place, so there is finally a single on-ramp to point newcomers to.",
+            ],
+          },
+        ],
+      },
+      {
+        heading: "The definition, and how we slice it",
+        blocks: [
+          {
+            type: "p",
+            text: "Here is our current working definition — a draft, meant to be argued with and refined:",
+          },
+          {
+            type: "p",
+            text: "*A recursive self-improvement system improves its own future performance by modifying one of its own building blocks — context, memory, skills, harness/scaffold code, or model parameters — using a feedback signal derived from its own activity, with the improvement carried forward to later tasks.*",
+          },
+          {
+            type: "p",
+            text: "A single label can't capture that. So rather than police who counts as \"real\" RSI, we describe each system along a set of dimensions:",
+          },
+          {
+            type: "list",
+            ordered: false,
+            items: [
+              "**What evolves (the artifact).** Which building block actually changes? This ranges from non-parametric artifacts — context, memory, skills, harness code — to genuinely parametric recursion where one model generation trains the next. \"Improving the context\" and \"retraining the weights\" are both self-improvement, but they are not the same thing.",
+              "**How it evolves (the mode).** Does experience arrive online as a stream or curriculum, is there a clean offline train/test split, or is it a hybrid that seeds a skill library offline and keeps evolving in use?",
+              "**Where the signal comes from.** What supervises the improvement — a rule-based check or execution result, an external verifier, an LLM acting as judge, or a self-generated reward? Every improvement loop is an implicit claim that some signal can stand in for human judgment.",
+              "**How far the loop closes.** How much human involvement remains, from human-in-the-loop at one end to a fully closed loop at the other.",
+              "**What we measure.** Final accuracy, the *gain* over a matched non-evolving baseline, the cost (tokens, compute, money), or the latency. A system can post high final accuracy with almost no RSI gain if it simply started strong — which is why gain, not accuracy, is often the honest metric.",
+            ],
+          },
+          {
+            type: "p",
+            text: "These are the same axes the benchmark list is tagged with, so the definition isn't just prose — you can filter the corpus by it.",
+          },
+        ],
+      },
+      {
+        heading: "Reading the corpus from several angles",
+        blocks: [
+          {
+            type: "p",
+            text: "The site is built so the same papers can be examined in more than one way:",
+          },
+          {
+            type: "list",
+            ordered: false,
+            items: [
+              "**Benchmark Paper List** — the curated benchmark corpus, with a filter board spanning seven dimensions (benchmark origin, RSI mode, RSI artifact, construction criteria, metric, benchmark creation, and evaluation). Values within a dimension combine with OR and dimensions combine with AND, so you can isolate, say, streaming online benchmarks that report gain and are scored by rule-based checks. Search across titles and abstracts, and sort by recency or by citation count.",
+              "**Citation graph** — a verified graph of how these papers cite one another, with pan-and-zoom on desktop and mobile, to read the corpus as a map rather than a list.",
+              "**Methods & Systems** — the methods side of the field: how self-improvement is actually done, kept alongside the benchmarks that measure it.",
+              "**Books & Courses** — the curated learning shelf: technical books, university courses, and other learning materials for getting oriented.",
+            ],
+          },
+        ],
+      },
+      {
+        heading: "Contribute",
+        blocks: [
+          {
+            type: "p",
+            text: "This is meant to be a living map, and it gets better with more eyes on it. If a benchmark, method, or learning resource is missing — or a taxonomy label looks wrong — please open a pull request or an issue on the repository. New entries come with the taxonomy metadata described above so they slot straight into the filter views.",
+          },
+          {
+            type: "list",
+            ordered: false,
+            items: [
+              "Repository and contribution guide: [github.com/Prism-Shadow/awesome-rsi](https://github.com/Prism-Shadow/awesome-rsi)",
+              "Background reading — the survey behind the 1,250-paper figure: [Recursive Self-Improvement in AI (arXiv:2607.07663)](https://arxiv.org/abs/2607.07663)",
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
     id: "release-notes-2026-08",
     kind: "Release notes",
     title: "Awesome RSI — The First Release",

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -403,6 +403,15 @@ a:hover {
   margin-bottom: 0;
 }
 
+.blog-footnote {
+  margin: 1.25rem 0 0;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.6;
+}
+
 .blog-article-body p + ul,
 .blog-article-body p + ol {
   margin-top: 0.25rem;

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -385,6 +385,29 @@ a:hover {
   gap: 0.75rem;
 }
 
+.blog-article-body ol {
+  margin: 0;
+  padding-left: 1.3rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.blog-article-body p {
+  margin: 0 0 1rem;
+  color: var(--body);
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+.blog-article-body p:last-child {
+  margin-bottom: 0;
+}
+
+.blog-article-body p + ul,
+.blog-article-body p + ol {
+  margin-top: 0.25rem;
+}
+
 .blog-article-body li {
   padding-left: 0.25rem;
   color: var(--body);


### PR DESCRIPTION
- Adds the first long-form blog post introducing Awesome RSI, plus the rendering needed to display it.
- New sectioned blog format (sections with paragraphs / lists / footnotes) in BlogTab.jsx, with minimal inline [label](url) / **bold** parsing and matching CSS.
- Intro post: RSI background (I.J. Good → seed AI → Bostrom), the three problems (fuzzy definition, explosive growth of 1,250+ papers, no learning path), and the three responses.
 - Definition section with the P(y|θ,C) framing, a PostTrainBench worked example, and the offline / online / mixed axes (GDPevo, EdgeBench, PostTrainBench).
 - Views, Books & Courses, and Contribute sections.
 - Removed the old first-release notes post.