### PR TITLE
Add Proteus v0.2.0 to Methods & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ We track the research on agents that get better by editing their own building bl
 2. **A website** — a [GitHub Pages site](https://prism-shadow.github.io/awesome-rsi/) that hosts the corpus as several views: a benchmark list with a multi-dimensional filter board, sortable by **date** or **citations**; a **citation graph**; a **Methods & Systems** list; and a **Books & Courses** shelf — so the same work can be read as a timeline, a leaderboard, or a map.
 3. **A blog** — longer-form writing on the field, starting with the introduction to this project.
 
+## Methods & Systems
+
+| System | Method | RSI mode | Artifact | Description |
+|---|---|---|---|---|
+| [Proteus](https://github.com/proteus-evolve/Proteus) ([v0.2.0](https://github.com/proteus-evolve/Proteus/releases/tag/v0.2.0)) | Agent system / evolution loop | Repeated / iterative | Harness code and declared surfaces | Harness-agnostic framework for context-fresh self-evolution episodes, validation-gated self-edits, snapshots, and measurement. |
+
 ## Contributing
 
 Contributions are welcome. If a benchmark, method, or learning resource is missing — or a taxonomy label looks wrong — please open a pull request or an issue. New entries should carry the taxonomy metadata used by the site's filter views (benchmark origin, RSI mode, artifact, construction criteria, metric, creation, and evaluation) so they slot directly into the comparison views.

--- a/site/src/components/MethodsTab.jsx
+++ b/site/src/components/MethodsTab.jsx
@@ -1,21 +1,65 @@
+import { methods } from "../data/methods.js";
+
+function MethodCard({ method }) {
+  return (
+    <article className="resource-card method-card">
+      <div className="method-card-meta">
+        <span className="paper-nick">{method.version}</span>
+        <span className="method-status">{method.status}</span>
+      </div>
+      <h3>
+        <a href={method.links[0].url} target="_blank" rel="noreferrer">{method.name}</a>
+      </h3>
+      <p>{method.description}</p>
+      <dl className="method-taxonomy">
+        {method.taxonomy.map(({ label, value }) => (
+          <div key={label}>
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="paper-tags" aria-label={`${method.name} categories`}>
+        {method.tags.map((tag) => <span className="tag" key={tag}>{tag}</span>)}
+      </div>
+      <div className="resource-links" aria-label={`${method.name} links`}>
+        {method.links.map((link) => (
+          <a href={link.url} target="_blank" rel="noreferrer" key={link.url}>
+            {link.label} ↗
+          </a>
+        ))}
+      </div>
+    </article>
+  );
+}
+
 export default function MethodsTab() {
   return (
-    <section className="methods-placeholder" aria-labelledby="methods-placeholder-title">
-      <div className="methods-placeholder-index" aria-hidden="true">02 / Methods</div>
-      <div>
-        <span className="methods-placeholder-kicker">Collection in progress</span>
-        <h2 id="methods-placeholder-title">Methods &amp; Systems</h2>
-        <p>
-          This section will collect reusable RSI methods, learning algorithms, agent architectures,
-          and self-improvement systems rather than benchmark papers.
-        </p>
-        <div className="methods-placeholder-scope" aria-label="Planned method categories">
-          <span>Learning methods</span>
-          <span>Agent systems</span>
-          <span>Training loops</span>
-          <span>Memory &amp; skills</span>
+    <>
+      <section className="methods-placeholder" aria-labelledby="methods-title">
+        <div className="methods-placeholder-index" aria-hidden="true">02 / Methods</div>
+        <div>
+          <span className="methods-placeholder-kicker">Open-source implementations</span>
+          <h2 id="methods-title">Methods &amp; Systems</h2>
+          <p>
+            Open-source systems and repeatable methods for building and evaluating self-improving
+            agents. Each entry identifies what evolves, how iteration works, and where to inspect
+            the implementation.
+          </p>
+          <div className="methods-placeholder-scope" aria-label="Method categories">
+            <span>Learning methods</span>
+            <span>Agent systems</span>
+            <span>Training loops</span>
+            <span>Memory &amp; skills</span>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+      <section className="resource-section" aria-labelledby="method-list-title">
+        <h2 id="method-list-title">Agent systems &amp; evolution loops</h2>
+        <div className="resource-grid">
+          {methods.map((method) => <MethodCard method={method} key={method.id} />)}
+        </div>
+      </section>
+    </>
   );
 }

--- a/site/src/data/methods.js
+++ b/site/src/data/methods.js
@@ -1,0 +1,23 @@
+export const methods = [
+  {
+    id: "proteus",
+    name: "Proteus",
+    version: "v0.2.0",
+    status: "Research preview",
+    description:
+      "An open-source, harness-agnostic framework for iterative self-evolution of agent harnesses. It runs context-fresh episodes against natural-language goals and evaluators, stages self-edits behind validation, and preserves snapshots for analysis.",
+    taxonomy: [
+      { label: "Method", value: "Agent system / evolution loop" },
+      { label: "RSI mode", value: "Repeated / iterative" },
+      { label: "Artifact", value: "Harness code and declared surfaces" },
+      { label: "Evaluation", value: "Visible or hidden evaluators" },
+    ],
+    tags: ["Harness code", "Agent system", "Training loop", "Open source"],
+    links: [
+      { label: "Code", url: "https://github.com/proteus-evolve/Proteus" },
+      { label: "v0.2.0 release", url: "https://github.com/proteus-evolve/Proteus/releases/tag/v0.2.0" },
+      { label: "Documentation", url: "https://github.com/proteus-evolve/Proteus#readme" },
+      { label: "Website", url: "https://proteus-evolve.github.io/" },
+    ],
+  },
+];

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1705,11 +1705,11 @@ a:hover {
   color: var(--muted);
 }
 
-/* ---------- methods placeholder ---------- */
+/* ---------- methods & systems ---------- */
 
 .methods-placeholder {
   min-height: 22rem;
-  margin-bottom: 2.5rem;
+  margin-bottom: 1.5rem;
   padding: clamp(2rem, 6vw, 4.5rem);
   display: grid;
   grid-template-columns: minmax(8rem, 0.32fr) minmax(0, 1fr);
@@ -1793,6 +1793,57 @@ a:hover {
   font-size: 0.66rem;
 }
 
+.method-card {
+  gap: 0;
+}
+
+.method-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
+}
+
+.method-status {
+  color: var(--muted);
+  font: 0.66rem var(--mono);
+}
+
+.method-taxonomy {
+  margin: 0.9rem 0 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.method-taxonomy > div {
+  min-width: 0;
+  padding: 0.7rem 0.8rem;
+  background: var(--surface-2);
+}
+
+.method-taxonomy > div + div {
+  border-left: 1px solid var(--line);
+}
+
+.method-taxonomy dt {
+  color: var(--muted);
+  font: 700 0.62rem var(--mono);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.method-taxonomy dd {
+  margin: 0.25rem 0 0;
+  color: var(--ink);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
 /* ---------- footer ---------- */
 
 .site-footer {
@@ -1840,4 +1891,8 @@ a:hover {
   .graph-legend { justify-content: flex-start; gap: 0.55rem 1rem; }
   .methods-placeholder { grid-template-columns: 1fr; gap: 1.2rem; padding: 2rem 1.25rem; }
   .methods-placeholder-index { min-height: 2rem; border-right: 0; border-bottom: 1px solid var(--line); }
+  .method-taxonomy { grid-template-columns: 1fr 1fr; }
+  .method-taxonomy > div + div { border-left: 0; }
+  .method-taxonomy > div:nth-child(even) { border-left: 1px solid var(--line); }
+  .method-taxonomy > div:nth-child(n + 3) { border-top: 1px solid var(--line); }
 }


### PR DESCRIPTION
## Summary

- add Proteus v0.2.0 to the README Methods & Systems table
- turn the website's Methods & Systems placeholder into a data-backed collection
- include method, RSI-mode, artifact, and evaluation metadata plus source, release, documentation, and website links

## Why it belongs

Proteus is an open-source, harness-agnostic framework for iterative self-evolution of agent harnesses. It runs context-fresh episodes against natural-language goals and evaluators, stages self-edits behind validation, and preserves snapshots for analysis. This makes it a direct fit for the collection's harness-code, agent-system, and training-loop scope.

## Validation

- npm ci
- npm run build

## Disclosure

I contribute to the Proteus project. The entry is intentionally factual, links to the tagged v0.2.0 GitHub release, and labels the project as a research preview.