### PR TITLE
Add Proteus to Methods & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ We track the research on agents that get better by editing their own building bl
 2. **A website** — a [GitHub Pages site](https://prism-shadow.github.io/awesome-rsi/) that hosts the corpus as several views: a benchmark list with a multi-dimensional filter board, sortable by **date** or **citations**; a **citation graph**; a **Methods & Systems** list; and a **Books & Courses** shelf — so the same work can be read as a timeline, a leaderboard, or a map.
 3. **A blog** — longer-form writing on the field, starting with the introduction to this project.
 
+## Open-source systems
+
+| System | RSI artifact | Description |
+|---|---|---|
+| [Proteus](https://github.com/proteus-evolve/Proteus) ([v0.3.0](https://github.com/proteus-evolve/Proteus/releases/tag/v0.3.0)) | Harness code and declared surfaces | Harness-agnostic framework for context-fresh self-evolution episodes, validation-gated self-edits, versioned snapshots, and measurement. |
+
 ## Contributing
 
 Contributions are welcome. If a benchmark, method, or learning resource is missing — or a taxonomy label looks wrong — please open a pull request or an issue. New entries should carry the taxonomy metadata used by the site's filter views (benchmark origin, RSI mode, artifact, construction criteria, metric, creation, and evaluation) so they slot directly into the comparison views.

--- a/site/src/components/MethodsTab.jsx
+++ b/site/src/components/MethodsTab.jsx
@@ -1,24 +1,35 @@
 import { useMemo, useState } from "react";
 import { methods } from "../data/methods.js";
+import { systems } from "../data/systems.js";
 import { methodCitationEdges } from "../data/methodCitationGraph.js";
 import { methodFilterDimensions, methodTaxonomy } from "../data/methodTaxonomy.js";
 import { localizeMethodDimensions } from "../data/methodTaxonomyZh.js";
 import FilterBar from "./FilterBar.jsx";
 import MethodCard from "./MethodCard.jsx";
+import SystemCard from "./SystemCard.jsx";
 import { methodFilterCopy, methodsCopy } from "../i18n.js";
 
 const INITIAL_SELECTIONS = Object.fromEntries(methodFilterDimensions.map(({ id }) => [id, []]));
-const YEARS = methods.map((method) => method.year);
+const methodEntries = [
+  ...methods.map((method) => ({
+    ...method,
+    entryType: "paper",
+    facets: methodTaxonomy[method.id],
+    corpusCitations: methodCitationEdges.filter((edge) => edge.target === method.id).length,
+  })),
+  ...systems.map((system) => ({
+    ...system,
+    entryType: "system",
+    published: system.released,
+    year: Number(system.released.slice(0, 4)),
+    venue: "Open-source system",
+    authors: [system.maintainers],
+    facets: system.taxonomy,
+    corpusCitations: 0,
+  })),
+];
+const YEARS = methodEntries.map((method) => method.year);
 const YEAR_BOUNDS = [Math.min(...YEARS), Math.max(...YEARS)];
-const METHOD_CITATION_COUNTS = Object.fromEntries(methods.map((method) => [
-  method.id,
-  methodCitationEdges.filter((edge) => edge.target === method.id).length,
-]));
-const indexedMethods = methods.map((method) => ({
-  ...method,
-  facets: methodTaxonomy[method.id],
-  corpusCitations: METHOD_CITATION_COUNTS[method.id] ?? 0,
-}));
 
 export default function MethodsTab({ lang }) {
   const [selections, setSelections] = useState(INITIAL_SELECTIONS);
@@ -33,13 +44,13 @@ export default function MethodsTab({ lang }) {
     dimension.id,
     Object.fromEntries(dimension.options.map((option) => [
       option.value,
-      indexedMethods.filter((method) => method.facets[dimension.id].includes(option.value)).length,
+      methodEntries.filter((method) => method.facets[dimension.id].includes(option.value)).length,
     ])),
   ])), []);
 
   const visible = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
-    return indexedMethods
+    return methodEntries
       .filter((method) => methodFilterDimensions.every(({ id }) =>
         selections[id].length === 0 || selections[id].some((value) => method.facets[id].includes(value))))
       .filter((method) => method.year >= yearRange[0] && method.year <= yearRange[1])
@@ -94,7 +105,7 @@ export default function MethodsTab({ lang }) {
         sortBy={sortBy}
         onSortChange={setSortBy}
         resultCount={visible.length}
-        totalCount={methods.length}
+        totalCount={methodEntries.length}
         onClear={clearFilters}
         lang={lang}
         copyOverride={filterText}
@@ -111,8 +122,10 @@ export default function MethodsTab({ lang }) {
         </div>
       ) : (
         <div className="paper-list method-list">
-          {visible.map((method) => <MethodCard method={method} lang={lang} key={method.id} />)}
-        </div>
+          {visible.map((method) => method.entryType === "system"
+            ? <SystemCard system={method} lang={lang} key={method.id} />
+            : <MethodCard method={method} lang={lang} key={method.id} />)}
+          </div>
       )}
     </section>
   );

--- a/site/src/components/SystemCard.jsx
+++ b/site/src/components/SystemCard.jsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { methodFilterDimensions } from "../data/methodTaxonomy.js";
+import { localizeMethodDimensions, localizeMethodValue } from "../data/methodTaxonomyZh.js";
+import { systemCardCopy } from "../i18n.js";
+
+function formatDate(iso, lang) {
+  return new Date(`${iso}T00:00:00Z`).toLocaleDateString(lang === "zh" ? "zh-CN" : "en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function SystemCard({ system, lang }) {
+  const [showProfile, setShowProfile] = useState(false);
+  const copy = systemCardCopy[lang];
+  const dimensions = localizeMethodDimensions(methodFilterDimensions, lang);
+  const summary = lang === "zh" ? system.summaryZh : system.summary;
+
+  return (
+    <article className="paper-card method-card system-card">
+      <div className="paper-top">
+        <span className="paper-nick">{system.nickname}</span>
+        <span className="method-status is-system">{copy.researchPreview}</span>
+        <span className="paper-meta">
+          <span>{system.version}</span>
+          <span>{formatDate(system.released, lang)}</span>
+        </span>
+      </div>
+      <h3 className="paper-title">
+        <a href={system.links[0].url} target="_blank" rel="noreferrer">{system.title}</a>
+      </h3>
+      <p className="paper-authors system-maintainers">
+        <strong>{copy.maintainers}</strong> {system.maintainers}
+      </p>
+      <p className="method-summary">{summary}</p>
+      <div className="method-artifacts" aria-label={dimensions.find(({ id }) => id === "artifact")?.label}>
+        {system.taxonomy.artifact.map((value) => (
+          <span className="tag" key={value}>{localizeMethodValue("artifact", value, lang)}</span>
+        ))}
+      </div>
+      <div className="paper-links">
+        {system.links.map((link) => (
+          <a href={link.url} target="_blank" rel="noreferrer" key={link.url}>
+            {lang === "zh" ? link.labelZh : link.label}
+          </a>
+        ))}
+        <button
+          className="abstract-toggle"
+          type="button"
+          aria-expanded={showProfile}
+          onClick={() => setShowProfile((value) => !value)}
+        >
+          {showProfile ? copy.hideProfile : copy.showProfile}
+        </button>
+      </div>
+      {showProfile && (
+        <section className="taxonomy-profile" aria-label={copy.profileLabel}>
+          {dimensions.map((dimension) => (
+            <div className="taxonomy-profile-row" key={dimension.id}>
+              <strong>{dimension.label}</strong>
+              <div>
+                {system.taxonomy[dimension.id].map((value) => (
+                  <span key={value}>{localizeMethodValue(dimension.id, value, lang)}</span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+    </article>
+  );
+}

--- a/site/src/data/systems.js
+++ b/site/src/data/systems.js
@@ -1,0 +1,29 @@
+export const systems = [
+  {
+    id: "proteus",
+    nickname: "Proteus",
+    title: "Proteus: A Harness-Agnostic Self-Evolution Framework for AI Agents",
+    version: "v0.3.0",
+    released: "2026-08-24",
+    maintainers: "Proteus Authors",
+    summary: "An open-source, harness-agnostic framework for running and measuring iterative self-evolution. Each episode starts with a fresh model context, lets the agent edit declared harness surfaces, activates source changes only after validation, and preserves versioned snapshots of the evolution history.",
+    summaryZh: "一个与具体 Harness 解耦的开源自我演化框架，用于运行和测量迭代式自我改进。每个 episode 都使用全新的模型上下文，Agent 可以修改预先声明的 Harness 区域；代码改动通过验证后才会启用，版本化快照则保留完整的演化历史。",
+    taxonomy: {
+      artifact: ["Non-parametric", "Harness code", "Context", "Memory", "Skill"],
+      mode: ["Offline"],
+      topology: ["Sequential"],
+      selection: ["Artifact validation", "Instance result"],
+      updater: ["Self"],
+      source: ["Environment", "Executable verifier", "LLM feedback"],
+      feedback: ["Score", "Binary", "Non-binary", "Non-score", "Other"],
+      frequency: ["Trajectory"],
+      scope: ["General", "Specialized"],
+    },
+    links: [
+      { label: "GitHub", labelZh: "GitHub", url: "https://github.com/proteus-evolve/Proteus" },
+      { label: "v0.3.0 release", labelZh: "v0.3.0 版本", url: "https://github.com/proteus-evolve/Proteus/releases/tag/v0.3.0" },
+      { label: "Documentation", labelZh: "文档", url: "https://github.com/proteus-evolve/Proteus/tree/main/docs" },
+      { label: "Website", labelZh: "网站", url: "https://proteus-evolve.github.io/" },
+    ],
+  },
+];

--- a/site/src/i18n.js
+++ b/site/src/i18n.js
@@ -268,21 +268,38 @@ export const resourcesCopy = {
 
 export const methodsCopy = {
   en: {
-    noMethods: "No methods found",
+    noMethods: "No methods or systems found",
     noMethodsHint: "Try removing one of the filters or widening the publication range.",
     reset: "Reset all filters",
   },
   zh: {
-    noMethods: "没有符合条件的方法论文",
+    noMethods: "没有符合条件的方法或系统",
     noMethodsHint: "可以尝试减少筛选条件，或扩大发表年份范围。",
     reset: "重置全部筛选",
   },
 };
 
+export const systemCardCopy = {
+  en: {
+    researchPreview: "Research preview",
+    maintainers: "Maintained by",
+    showProfile: "Show system profile ▾",
+    hideProfile: "Hide system profile ▴",
+    profileLabel: "RSI system profile",
+  },
+  zh: {
+    researchPreview: "研究预览",
+    maintainers: "维护者",
+    showProfile: "展开系统维度 ▾",
+    hideProfile: "收起系统维度 ▴",
+    profileLabel: "RSI 系统维度档案",
+  },
+};
+
 export const methodFilterCopy = {
   en: {
-    filterPapers: "Filter methods",
-    resultCount: (visible, total) => ({ before: "", visible, middle: " of ", total, after: " methods" }),
+    filterPapers: "Filter methods and systems",
+    resultCount: (visible, total) => ({ before: "", visible, middle: " of ", total, after: " methods and systems" }),
     all: "All",
     includes: "Includes",
     note: "Note",
@@ -297,22 +314,22 @@ export const methodFilterCopy = {
     logic: "OR within rows",
     logicAnd: "AND across rows",
     reset: "Reset all filters",
-    searchPlaceholder: "Search methods by title, author, summary, venue, or arXiv ID",
-    sortPapers: "Method sorting",
+    searchPlaceholder: "Search methods and systems by title, author, summary, venue, or identifier",
+    sortPapers: "Methods and systems sorting",
     sort: "Sort",
     newest: "Newest",
     mostCited: "Most cited",
     numericHelp: {
-      summary: "Filter methods by the year their arXiv record was first posted.",
+      summary: "Filter entries by the year they were first publicly released.",
       items: [
-        { term: "First posted", description: "Keep papers whose first arXiv submission falls within the selected interval." },
+        { term: "First posted", description: "Use the first arXiv submission for papers and the listed release date for systems." },
       ],
-      note: "Venue badges show later conference publication separately from the original arXiv date.",
+      note: "Paper venue badges and system release labels are shown separately from this date filter.",
     },
   },
   zh: {
-    filterPapers: "筛选方法",
-    resultCount: (visible, total) => ({ before: "共 ", visible, middle: " / ", total, after: " 篇方法论文" }),
+    filterPapers: "筛选方法与系统",
+    resultCount: (visible, total) => ({ before: "共 ", visible, middle: " / ", total, after: " 项方法与系统" }),
     all: "全部",
     includes: "包含",
     note: "说明",
@@ -327,17 +344,17 @@ export const methodFilterCopy = {
     logic: "同一行内按“或”筛选",
     logicAnd: "不同行之间按“且”筛选",
     reset: "重置全部筛选",
-    searchPlaceholder: "搜索方法名称、作者、方法概述、会议或 arXiv ID",
-    sortPapers: "方法排序",
+    searchPlaceholder: "搜索方法或系统名称、作者、概述、来源或标识符",
+    sortPapers: "方法与系统排序",
     sort: "排序",
     newest: "最新公开",
     mostCited: "引用最多",
     numericHelp: {
-      summary: "按照论文首次出现在 arXiv 的年份筛选方法。",
+      summary: "按照条目首次公开的年份筛选方法与系统。",
       items: [
-        { term: "首次公开年份", description: "只保留首次 arXiv 提交时间位于所选年份范围内的论文。" },
+        { term: "首次公开年份", description: "论文使用首次 arXiv 提交时间，系统使用页面列出的版本发布时间。" },
       ],
-      note: "卡片上的会议标签单独表示论文后来正式录用的情况。",
+      note: "论文会议标签和系统版本信息会与该日期筛选项分开展示。",
     },
   },
 };

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1798,6 +1798,17 @@ a:hover {
   color: var(--amber);
 }
 
+.method-status.is-system {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+}
+
+.system-maintainers strong {
+  color: var(--ink);
+  font-size: 0.76rem;
+}
+
 .method-summary {
   max-width: 64rem;
   margin: 0.65rem 0 0;


### PR DESCRIPTION
## Summary

- migrate the Proteus contribution from #3 onto the current Methods & Systems architecture
- list Proteus v0.3.0 alongside method papers with matching RSI taxonomy, sorting, and search support
- provide a dedicated bilingual system card with repository, release, documentation, and website links
- add Proteus to the README open-source systems list

## Attribution

This PR supersedes #3 and adapts the original contribution by @yichen14 to the redesigned site. Thank you for introducing Proteus to Awesome RSI and for the clear project metadata and disclosure.

## Validation

- `npm ci`
- `npm run build`
- validated the system profile against all nine current RSI taxonomy dimensions